### PR TITLE
Symbols break LimitDecimals function

### DIFF
--- a/src/code.js
+++ b/src/code.js
@@ -74,10 +74,14 @@ function getGradientRotation(gradientTransform) {
 }
 
 function LimitDecimals(Number, Decimals) { // Limit decimals to x places and round up/down
-    if (isNaN(Number)) return 0;
-    if (Decimals !== undefined && isNaN(Decimals)) Decimals = null;
-
-    return parseFloat(Number.toFixed(Decimals));
+    if(typeof Number === 'number'){
+        if (isNaN(Number)) return 0;
+        if (Decimals !== undefined && isNaN(Decimals)) Decimals = null;
+    
+        return parseFloat(Number.toFixed(Decimals));
+    } else {
+        return 0;
+    }
 }
 
 const Fonts = {


### PR DESCRIPTION
For some Figma designs I had been given, it would not successfully convert them. Looking in console I saw that this function was the culprit. Checking the number input type and returning 0 if it wasn't a number seemed to fix the issue I was having.
```javascript
function LimitDecimals(Number, Decimals) { // Limit decimals to x places and round up/down
    if(typeof Number === 'number'){
        if (isNaN(Number)) return 0;
        if (Decimals !== undefined && isNaN(Decimals)) Decimals = null;

        return parseFloat(Number.toFixed(Decimals));
    } else {
        return 0;
    }
}
``` 

![image](https://github.com/NoTwistedHere/Figma-to-Roblox/assets/67559704/eefa0adb-c568-41d2-9d68-42add4bce138)
![image](https://github.com/NoTwistedHere/Figma-to-Roblox/assets/67559704/d364d8a8-1662-4fd3-ba0d-cbb7a07f1f8b)
